### PR TITLE
Fix v80 Bracken not grabbing

### DIFF
--- a/Patches/entity/BrackenAIPatch.cs
+++ b/Patches/entity/BrackenAIPatch.cs
@@ -29,7 +29,7 @@ namespace SnatchinBracken.Patches
         // Prevents the Bracken AI from choosing another favorite location other than the favorite room, if configured for it
         [HarmonyPostfix]
         [HarmonyPatch(typeof(EnemyAI), "ChooseFarthestNodeFromPosition")]
-        static void FarthestNodeAdjustment(EnemyAI __instance, ref Transform __result, Vector3 pos, bool avoidLineOfSight = false, int offset = 0, bool doAsync = false, int maxAsyncIterations = 50, bool capDistance = false)
+        static void FarthestNodeAdjustment(EnemyAI __instance, ref Transform __result, Vector3 pos, bool avoidLineOfSight = false, int offset = 0, bool doAsync = false, int maxAsyncIterations = 50, int capDistance = -1)
         {
             if (__instance is FlowermanAI flowermanAI)
             {


### PR DESCRIPTION
From decompiled game files Assembly-CSharp.dll is the same md5sum between v80 and v81 so I believe it broke in v80

(Limitation - I did not test LethalCompany v79 and v80. I only tested v81, but I did depotdownloader comparisons between the dlls)

ChooseFarthestNodeFromPosition changed its parameter type from v79 to v80 that Harmony tries to mess with ---> type failure. Basically

  v79: public Transform ChooseFarthestNodeFromPosition(..., bool capDistance = false)
  v80: public Transform ChooseFarthestNodeFromPosition(..., int capDistance = -1)

changed from v79 to v80. So I just change the type failure